### PR TITLE
Add support fort quick command handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Set up your controllers:
 ```php
 use Cake\Controller\Controller;
 use Robotusers\Commander\CommandBusAwareInterface;
-use Robotusers\Commander\CommandBusAwareTrait;
+use Robotusers\Tactician\Bus\CommandBusAwareTrait;
 
 class OrdersController extends Controller implements CommandBusAwareInterface
 {
@@ -47,6 +47,10 @@ class OrdersController extends Controller implements CommandBusAwareInterface
         // ...
         $command = new MakeOrderCommand($data);
         $this->handleCommand($command);
+        // ...
+
+        // or using quick convention enabled command handling:
+        $this->handleCommand('MakeOrder', $data);
         // ...
    }
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         ],
         "cs-check": "phpcs --colors -p ./src ./tests",
         "cs-fix": "phpcbf --colors ./src ./tests",
-        "stan-check": "phpstan analyse ./src -l 1",
+        "stan-check": "phpstan analyse ./src -l 7",
         "test": "phpunit --colors=always"
     }
 }

--- a/src/Bus/CommandBusAwareTrait.php
+++ b/src/Bus/CommandBusAwareTrait.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Robert Pustułka <r.pustulka@robotusers.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Robotusers\Tactician\Bus;
+
+use Robotusers\Commander\CommandBusAwareTrait as BaseTrait;
+
+/**
+ *
+ * @author Robert Pustułka <r.pustulka@robotusers.com>
+ */
+trait CommandBusAwareTrait
+{
+    use BaseTrait {
+        handleCommand as private __handleCommand;
+    }
+
+    /**
+     * Wrapper for command bus `handle()` method.
+     *
+     * @param mixed $command Command class.
+     * @param mixed $args Command arguments.
+     * @return mixed
+     */
+    public function handleCommand($command, ...$args)
+    {
+        return $this->getCommandBus()->handle($command, ...$args);
+    }
+}

--- a/src/Bus/TacticianAdapter.php
+++ b/src/Bus/TacticianAdapter.php
@@ -84,7 +84,7 @@ class TacticianAdapter extends BaseAdapter
      * Resolves command class name.
      *
      * @param string $name Name,
-     * @return string
+     * @return string|bool
      */
     protected function resolveClassName($name)
     {

--- a/src/Bus/TacticianAdapter.php
+++ b/src/Bus/TacticianAdapter.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Robert Pustułka <r.pustulka@robotusers.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Robotusers\Tactician\Bus;
+
+use Cake\Core\App;
+use Cake\Core\InstanceConfigTrait;
+use League\Tactician\CommandBus;
+use Robotusers\Commander\Adapter\TacticianAdapter as BaseAdapter;
+
+/**
+ * Description of TacticianAdapter
+ *
+ * @author Robert Pustułka <r.pustulka@robotusers.com>
+ */
+class TacticianAdapter extends BaseAdapter
+{
+
+    use InstanceConfigTrait;
+
+    /**
+     * Config.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'commandNamespace' => 'Model\\Command',
+        'commandSuffix' => 'Command'
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param CommandBus $commandBus Tactician command bus.
+     * @param array $config Config.
+     */
+    public function __construct(CommandBus $commandBus, array $config = [])
+    {
+        parent::__construct($commandBus);
+
+        $this->config($config);
+    }
+
+    /**
+     * Handles the command.
+     *
+     * @param string|object $command Command instance or name.
+     * @param mixed $args Additional arguments for command.
+     * @return mixed
+     */
+    public function handle($command, ...$args)
+    {
+        if (is_string($command)) {
+            $class = $this->resolveClassName($command);
+            $command = new $class(...$args);
+        }
+
+        return parent::handle($command);
+    }
+
+    /**
+     * Resolves command class name.
+     *
+     * @param string $name Name,
+     * @return string
+     */
+    protected function resolveClassName($name)
+    {
+        return App::className($name, $this->_config['commandNamespace'], $this->_config['commandSuffix']);
+    }
+}

--- a/src/Event/BusListener.php
+++ b/src/Event/BusListener.php
@@ -30,9 +30,9 @@ use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use InvalidArgumentException;
 use League\Tactician\CommandBus;
-use Robotusers\Commander\Adapter\TacticianAdapter;
 use Robotusers\Commander\CommandBusAwareInterface;
 use Robotusers\Commander\CommandBusInterface;
+use Robotusers\Tactician\Bus\TacticianAdapter;
 
 /**
  * Event listener for a command bus.
@@ -55,7 +55,8 @@ class BusListener implements EventListenerInterface
         'events' => [
             'Controller.initialize',
             'Model.initialize'
-        ]
+        ],
+        'adapter' => []
     ];
 
     /**
@@ -69,8 +70,8 @@ class BusListener implements EventListenerInterface
      */
     public function __construct($commandBus, array $config = [])
     {
-        $this->setCommandBus($commandBus);
         $this->config($config);
+        $this->setCommandBus($commandBus);
     }
 
     /**
@@ -91,7 +92,7 @@ class BusListener implements EventListenerInterface
                 throw new InvalidArgumentException($message);
             }
 
-            $commandBus = new TacticianAdapter($commandBus);
+            $commandBus = new TacticianAdapter($commandBus, $this->_config['adapter']);
         }
 
         $this->commandBus = $commandBus;

--- a/tests/TestCase/Bus/CommandBusAwareTraitTest.php
+++ b/tests/TestCase/Bus/CommandBusAwareTraitTest.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Robert Pustułka <r.pustulka@robotusers.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Robotusers\Tactician\Test;
+
+use PHPUnit\Framework\TestCase;
+use Robotusers\Commander\CommandBusInterface;
+use Robotusers\Tactician\Bus\CommandBusAwareTrait;
+use stdClass;
+
+/**
+ * @author Robert Pustułka <r.pustulka@robotusers.com>
+ */
+class CommandBusAwareTraitTest extends TestCase
+{
+
+    public function testHandleCommand()
+    {
+        $object = $this->getMockForTrait(CommandBusAwareTrait::class);
+        $bus = $this->createMock(CommandBusInterface::class);
+        $command = 'Foo';
+        $argument = 'Bar';
+        $result = new stdClass();
+
+        $bus->expects($this->once())
+            ->method('handle')
+            ->with($command, $argument)
+            ->willReturn($result);
+
+        $object->setCommandBus($bus);
+        $return = $object->handleCommand($command, $argument);
+        $this->assertSame($result, $return);
+    }
+}

--- a/tests/TestCase/Bus/CommandBusAwareTraitTest.php
+++ b/tests/TestCase/Bus/CommandBusAwareTraitTest.php
@@ -25,15 +25,15 @@
 
 namespace Robotusers\Tactician\Test;
 
-use PHPUnit\Framework\TestCase;
 use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Bus\CommandBusAwareTrait;
+use Robotusers\Tactician\Test\TestCase\Php71TestCase;
 use stdClass;
 
 /**
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class CommandBusAwareTraitTest extends TestCase
+class CommandBusAwareTraitTest extends Php71TestCase
 {
 
     public function testHandleCommand()

--- a/tests/TestCase/Bus/TacticianAdapterTest.php
+++ b/tests/TestCase/Bus/TacticianAdapterTest.php
@@ -22,19 +22,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace App\Model\Command;
+
+namespace Robotusers\Tactician\Test\TestCase\Bus;
+
+use App\Model\Command\FooCommand;
+use Cake\TestSuite\TestCase;
+use League\Tactician\CommandBus;
+use Robotusers\Tactician\Bus\TacticianAdapter;
 
 /**
+ * Description of TacticianAdapter
+ *
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class FooCommand
+class TacticianAdapterTest extends TestCase
 {
-    public $arg1;
-    public $arg2;
-
-    public function __construct($arg1 = null, $arg2 = null)
+    public function testHandle()
     {
-        $this->arg1 = $arg1;
-        $this->arg2 = $arg2;
+        $commandBus = $this->createMock(CommandBus::class);
+        $commandBus->expects($this->once())
+            ->method('handle')
+            ->with($this->logicalAnd(
+                $this->isInstanceOf(FooCommand::class),
+                $this->callback(function ($command) {
+                    return $command->arg1 === 'Bar';
+                }),
+                $this->callback(function ($command) {
+                    return $command->arg2 === 'Baz';
+                })
+            ));
+
+        $adapter = new TacticianAdapter($commandBus);
+
+        $adapter->handle('Foo', 'Bar', 'Baz');
     }
 }

--- a/tests/TestCase/Core/BusMiddlewareTest.php
+++ b/tests/TestCase/Core/BusMiddlewareTest.php
@@ -25,28 +25,21 @@
 namespace Robotusers\Tactician\Test\TestCase\Core;
 
 use Cake\Event\EventManager;
-use Cake\TestSuite\TestCase;
 use League\Tactician\CommandBus;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Robotusers\Tactician\Core\BusApplicationInterface;
 use Robotusers\Tactician\Core\BusMiddleware;
 use Robotusers\Tactician\Event\BusListener;
+use Robotusers\Tactician\Test\TestCase\Php71TestCase;
 
 /**
  * Description of BusMiddlewareTest
  *
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class BusMiddlewareTest extends TestCase
+class BusMiddlewareTest extends Php71TestCase
 {
-    public function setUp()
-    {
-        $this->skipIf(version_compare(PHP_VERSION, '7.1') < 0);
-
-        parent::setUp();
-    }
-
     public function testInvoke()
     {
         $request = $this->createMock(ServerRequestInterface::class);

--- a/tests/TestCase/Event/BusListenerTest.php
+++ b/tests/TestCase/Event/BusListenerTest.php
@@ -26,12 +26,12 @@
 namespace Robotusers\Tactician\Test\TestCase\Event;
 
 use Cake\Event\Event;
-use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use League\Tactician\CommandBus;
 use Robotusers\Commander\CommandBusAwareInterface;
 use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Event\BusListener;
+use Robotusers\Tactician\Test\TestCase\Php71TestCase;
 use stdClass;
 
 /**
@@ -39,14 +39,8 @@ use stdClass;
  *
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class BusListenerTest extends TestCase
+class BusListenerTest extends Php71TestCase
 {
-    public function setUp()
-    {
-        $this->skipIf(version_compare(PHP_VERSION, '7.1') < 0);
-
-        parent::setUp();
-    }
 
     public function testCommandBusInterface()
     {

--- a/tests/TestCase/Event/QuickStartTest.php
+++ b/tests/TestCase/Event/QuickStartTest.php
@@ -26,26 +26,19 @@ namespace Robotusers\Tactician\Test\TestCase\Event;
 
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\TestSuite\TestCase;
 use Robotusers\Commander\CommandBusAwareInterface;
 use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Event\BusListener;
 use Robotusers\Tactician\Event\QuickStart;
+use Robotusers\Tactician\Test\TestCase\Php71TestCase;
 
 /**
  * Description of QuickStartTest
  *
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class QuickStartTest extends TestCase
+class QuickStartTest extends Php71TestCase
 {
-    public function setUp()
-    {
-        $this->skipIf(version_compare(PHP_VERSION, '7.1') < 0);
-
-        parent::setUp();
-    }
-
     public function testSetUp()
     {
         QuickStart::setUp();

--- a/tests/TestCase/Php71TestCase.php
+++ b/tests/TestCase/Php71TestCase.php
@@ -22,38 +22,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+namespace Robotusers\Tactician\Test\TestCase;
 
-namespace Robotusers\Tactician\Test\TestCase\Bus;
-
-use App\Model\Command\FooCommand;
-use League\Tactician\CommandBus;
-use Robotusers\Tactician\Bus\TacticianAdapter;
-use Robotusers\Tactician\Test\TestCase\Php71TestCase;
+use Cake\TestSuite\TestCase;
 
 /**
- * Description of TacticianAdapter
+ * Description of Php71TestCase
  *
  * @author Robert Pustułka <r.pustulka@robotusers.com>
  */
-class TacticianAdapterTest extends Php71TestCase
+class Php71TestCase extends TestCase
 {
-    public function testHandle()
+    public function setUp()
     {
-        $commandBus = $this->createMock(CommandBus::class);
-        $commandBus->expects($this->once())
-            ->method('handle')
-            ->with($this->logicalAnd(
-                $this->isInstanceOf(FooCommand::class),
-                $this->callback(function ($command) {
-                    return $command->arg1 === 'Bar';
-                }),
-                $this->callback(function ($command) {
-                    return $command->arg2 === 'Baz';
-                })
-            ));
+        $this->skipIf(version_compare(PHP_VERSION, '7.1') < 0);
 
-        $adapter = new TacticianAdapter($commandBus);
-
-        $adapter->handle('Foo', 'Bar', 'Baz');
+        parent::setUp();
     }
 }


### PR DESCRIPTION
This allows for quick command handling skipping the need for instantating command classes and leveraging command naming conventions.

Instead of:
```php
use App\Model\Command\FooCommand;

$command = new FooCommand($arg1, $arg2);
$this->handleCommand($command);
```

You can:
```php
$this->handleCommand('Foo', $arg1, $arg2);
```

This is achieved by using the custom `TacticianAdapter`.