### PR TITLE
Add console command/shell support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ For more information, read [the docs](https://github.com/robotusers/commander/bl
 
 Next you should configure the command bus which will be injected into your controllers and models that implement the `CommandBusAwareInterface`.
 
+#### Console (CakePHP 3.6+)
+
+For console integration Tactician plugin provides a `CommandFactory` that injects a command bus into compatible console shells and commands.
+
+Set up your `CommandRunner` as below:
+
+```php
+
+use App\Application;
+use Cake\Console\CommandRunner;
+use Cake\Console\CommandFactory;
+use Tactician\Console\CommandFactory as TacticianCommandFactory;
+
+$application = new Application(dirname(__DIR__) . '/config');
+$cakeFactory = new CommandFactory(); // or any other custom factory (ie. CakePHP DI plugin DIC-compatible factory)
+$factory = new TacticianCommandFactory($cakeFactory, $application);
+
+$runner = new CommandRunner($application, 'cake', $factory);
+exit($runner->run($argv));
+
 #### Application hook (CakePHP 3.3+)
 
 If your application supports middleware you can configure the command bus using an application hook.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require-dev": {
         "cakephp/cakephp": "dev-3.next as 3.6.0",
         "cakephp/cakephp-codesniffer": "*",
-        "phpunit/phpunit": "^5.6|^6.0",
-        "robotusers/commander": "^0.2"
+        "phpunit/phpunit": "^5.6|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,38 @@
 {
-	"name": "robotusers/cakephp-tactician",
-	"description": "CakePHP Tactician plugin",
-	"homepage": "https://github.com/robotusers/cakephp-tactician",
-	"type": "cakephp-plugin",
-	"license": "MIT",
-	"require": {
-		"php": ">=5.6",
-		"cakephp/core": "~3.1",
-		"cakephp/datasource": "~3.1",
-		"league/tactician": "^1.0"
-	},
-	"suggest": {
-		"cakephp/event": "If you want to use TacticianListener.",
-		"robotusers/commander": "If you want to use TacticianListener."
-	},
-	"require-dev": {
-		"cakephp/cakephp": "~3.5",
-		"cakephp/cakephp-codesniffer": "*",
-		"phpunit/phpunit": "^5.6|^6.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"Robotusers\\Tactician\\": "src"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Cake\\Test\\": "vendor/cakephp/cakephp/tests",
-			"Robotusers\\Tactician\\Test\\": "tests",
-			"App\\": "tests/test_app"
-		}
-	},
+    "name": "robotusers/cakephp-tactician",
+    "description": "CakePHP Tactician plugin",
+    "homepage": "https://github.com/robotusers/cakephp-tactician",
+    "type": "cakephp-plugin",
+    "license": "MIT",
+    "require": {
+        "php": ">=5.6",
+        "cakephp/core": "~3.4",
+        "cakephp/datasource": "~3.1",
+        "league/tactician": "^1.0"
+    },
+    "suggest": {
+        "cakephp/cakephp": "Install ^3.6 if you want to use CommandFactory.",
+        "cakephp/event": "Install ^3.4 if you want to use BusListener.",
+        "robotusers/commander": "Install ^0.2 if you want to use BusListener."
+    },
+    "require-dev": {
+        "cakephp/cakephp": "dev-3.next as 3.6.0",
+        "cakephp/cakephp-codesniffer": "*",
+        "phpunit/phpunit": "^5.6|^6.0",
+        "robotusers/commander": "^0.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Robotusers\\Tactician\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests",
+            "Robotusers\\Tactician\\Test\\": "tests",
+            "App\\": "tests/test_app"
+        }
+    },
     "scripts": {
         "check": [
             "@test",

--- a/src/Bus/TacticianAdapter.php
+++ b/src/Bus/TacticianAdapter.php
@@ -60,7 +60,7 @@ class TacticianAdapter extends BaseAdapter
     {
         parent::__construct($commandBus);
 
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -25,8 +25,10 @@
 namespace Robotusers\Tactician\Console;
 
 use Cake\Console\CommandFactoryInterface;
+use League\Tactician\CommandBus;
 use Robotusers\Commander\CommandBusAwareInterface;
 use Robotusers\Commander\CommandBusInterface;
+use Robotusers\Tactician\Bus\TacticianAdapter;
 use Robotusers\Tactician\Core\BusApplicationInterface;
 
 /**
@@ -71,7 +73,11 @@ class CommandFactory implements CommandFactoryInterface
     public function getCommandBus()
     {
         if ($this->commandBus === null) {
-            $this->commandBus = $this->app->commandBus();
+            $commandBus = $this->app->commandBus();
+            if ($commandBus instanceof CommandBus) {
+                $commandBus = new TacticianAdapter($commandBus);
+            }
+            $this->commandBus = $commandBus;
         }
 
         return $this->commandBus;

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -26,6 +26,7 @@ namespace Robotusers\Tactician\Console;
 
 use Cake\Console\CommandFactoryInterface;
 use Robotusers\Commander\CommandBusAwareInterface;
+use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Core\BusApplicationInterface;
 
 /**

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Robert Pustułka <robert.pustulka@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Robotusers\Tactician\Console;
+
+use Cake\Console\CommandFactoryInterface;
+use Robotusers\Commander\CommandBusAwareInterface;
+use Robotusers\Tactician\Core\BusApplicationInterface;
+
+/**
+ * CommandFactory class.
+ *
+ * @author Robert Pustułka <robert.pustulka@gmail.com>
+ */
+class CommandFactory implements CommandFactoryInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    protected $commandBus;
+
+    /**
+     * @var BusApplicationInterface
+     */
+    protected $app;
+
+    /**
+     * @var CommandFactoryInterface
+     */
+    protected $factory;
+
+    /**
+     * Constructor.
+     *
+     * @param CommandFactoryInterface $factory Command Factory.
+     * @param BusApplicationInterface $app Application with commandBus hook.
+     */
+    public function __construct(CommandFactoryInterface $factory, BusApplicationInterface $app)
+    {
+        $this->factory = $factory;
+        $this->app = $app;
+    }
+
+    /**
+     * Command bus getter.
+     *
+     * @return CommandBusInterface
+     */
+    public function getCommandBus()
+    {
+        if ($this->commandBus === null) {
+            $this->commandBus = $this->app->commandBus();
+        }
+
+        return $this->commandBus;
+    }
+
+    /**
+     * Injects a command bus into a compatible console command/shell.
+     *
+     * {@inheritDoc}
+     */
+    public function create($className)
+    {
+        $command = $this->factory->create($className);
+        if ($command instanceof CommandBusAwareInterface) {
+            $commandBus = $this->getCommandBus();
+            $command->setCommandBus($commandBus);
+        }
+
+        return $command;
+    }
+}

--- a/src/Core/BusMiddleware.php
+++ b/src/Core/BusMiddleware.php
@@ -25,6 +25,7 @@
 
 namespace Robotusers\Tactician\Core;
 
+use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -60,6 +61,9 @@ class BusMiddleware
     public function __construct(BusApplicationInterface $application, EventManager $eventManager = null, array $config = [])
     {
         $this->application = $application;
+        if ($eventManager === null && $application instanceof EventDispatcherInterface) {
+            $eventManager = $application->getEventManager();
+        }
         $this->eventManager = $eventManager ?: EventManager::instance();
         $this->config = $config;
     }

--- a/src/Event/BusListener.php
+++ b/src/Event/BusListener.php
@@ -70,7 +70,7 @@ class BusListener implements EventListenerInterface
      */
     public function __construct($commandBus, array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
         $this->setCommandBus($commandBus);
     }
 
@@ -118,7 +118,7 @@ class BusListener implements EventListenerInterface
      */
     public function injectCommandBus(Event $event)
     {
-        $subject = $event->subject();
+        $subject = $event->getSubject();
         if ($subject instanceof CommandBusAwareInterface) {
             $subject->setCommandBus($this->commandBus);
         }

--- a/src/Locator/ConventionsLocator.php
+++ b/src/Locator/ConventionsLocator.php
@@ -64,7 +64,7 @@ class ConventionsLocator extends ObjectRegistry implements HandlerLocator
      */
     public function __construct(array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
     }
 
     /**

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -26,23 +26,24 @@ namespace Robotusers\Tactician\Test\TestCase\Console;
 
 use App\Console\TestCommand;
 use Cake\Console\CommandFactoryInterface;
-use Cake\TestSuite\TestCase;
 use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Console\CommandFactory;
 use Robotusers\Tactician\Core\BusApplicationInterface;
+use Robotusers\Tactician\Test\TestCase\Php71TestCase;
 
 /**
  * @author Robert Pustułka <robert.pustulka@gmail.com>
  */
-class CommandFactoryTest extends TestCase
+class CommandFactoryTest extends Php71TestCase
 {
+
     public function testGetCommandBus()
     {
         $commandFactory = $this->createMock(CommandFactoryInterface::class);
         $app = $this->createMock(BusApplicationInterface::class);
 
         $app->method('commandBus')
-            ->willReturnCallback(function(){
+            ->willReturnCallback(function () {
                 return $this->createMock(CommandBusInterface::class);
             });
         $bus1 = $app->commandBus();

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -24,6 +24,7 @@
  */
 namespace Robotusers\Tactician\Test\TestCase\Console;
 
+use App\Console\TestCommand;
 use Cake\Console\CommandFactoryInterface;
 use Cake\TestSuite\TestCase;
 use Robotusers\Commander\CommandBusInterface;
@@ -52,5 +53,28 @@ class CommandFactoryTest extends TestCase
         $bus1 = $factory->getCommandBus();
         $bus2 = $factory->getCommandBus();
         $this->assertSame($bus2, $bus1);
+    }
+
+    public function testCreate()
+    {
+        $commandFactory = $this->createMock(CommandFactoryInterface::class);
+        $app = $this->createMock(BusApplicationInterface::class);
+        $commandBus = $this->createMock(CommandBusInterface::class);
+        $command = new TestCommand;
+
+        $app->method('commandBus')
+            ->willReturn($commandBus);
+
+        $commandFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(TestCommand::class)
+            ->willReturn($command);
+
+        $factory = new CommandFactory($commandFactory, $app);
+
+        $result = $factory->create(TestCommand::class);
+        $this->assertInstanceOf(TestCommand::class, $result);
+        $this->assertSame($commandBus, $result->getCommandBus());
     }
 }

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -26,6 +26,7 @@ namespace Robotusers\Tactician\Test\TestCase\Console;
 
 use App\Console\TestCommand;
 use Cake\Console\CommandFactoryInterface;
+use League\Tactician\CommandBus;
 use Robotusers\Commander\CommandBusInterface;
 use Robotusers\Tactician\Console\CommandFactory;
 use Robotusers\Tactician\Core\BusApplicationInterface;
@@ -53,6 +54,26 @@ class CommandFactoryTest extends Php71TestCase
         $factory = new CommandFactory($commandFactory, $app);
         $bus1 = $factory->getCommandBus();
         $bus2 = $factory->getCommandBus();
+        $this->assertSame($bus2, $bus1);
+    }
+
+    public function testGetCommandBusTactician()
+    {
+        $commandFactory = $this->createMock(CommandFactoryInterface::class);
+        $app = $this->createMock(BusApplicationInterface::class);
+
+        $app->method('commandBus')
+            ->willReturnCallback(function () {
+                return $this->createMock(CommandBus::class);
+            });
+        $bus1 = $app->commandBus();
+        $bus2 = $app->commandBus();
+        $this->assertNotSame($bus2, $bus1);
+
+        $factory = new CommandFactory($commandFactory, $app);
+        $bus1 = $factory->getCommandBus();
+        $bus2 = $factory->getCommandBus();
+        $this->assertInstanceOf(CommandBusInterface::class, $bus1);
         $this->assertSame($bus2, $bus1);
     }
 

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Robert Pustułka <robert.pustulka@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace Robotusers\Tactician\Test\TestCase\Console;
+
+use Cake\Console\CommandFactoryInterface;
+use Cake\TestSuite\TestCase;
+use Robotusers\Commander\CommandBusInterface;
+use Robotusers\Tactician\Console\CommandFactory;
+use Robotusers\Tactician\Core\BusApplicationInterface;
+
+/**
+ * @author Robert Pustułka <robert.pustulka@gmail.com>
+ */
+class CommandFactoryTest extends TestCase
+{
+    public function testGetCommandBus()
+    {
+        $commandFactory = $this->createMock(CommandFactoryInterface::class);
+        $app = $this->createMock(BusApplicationInterface::class);
+
+        $app->method('commandBus')
+            ->willReturnCallback(function(){
+                return $this->createMock(CommandBusInterface::class);
+            });
+        $bus1 = $app->commandBus();
+        $bus2 = $app->commandBus();
+        $this->assertNotSame($bus2, $bus1);
+
+        $factory = new CommandFactory($commandFactory, $app);
+        $bus1 = $factory->getCommandBus();
+        $bus2 = $factory->getCommandBus();
+        $this->assertSame($bus2, $bus1);
+    }
+}

--- a/tests/test_app/Console/TestCommand.php
+++ b/tests/test_app/Console/TestCommand.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Robert Pustułka <robert.pustulka@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace App\Console;
+
+use Cake\Console\Command;
+use Robotusers\Commander\CommandBusAwareInterface;
+use Robotusers\Commander\CommandBusAwareTrait;
+
+/**
+ * @author Robert Pustułka <robert.pustulka@gmail.com>
+ */
+class TestCommand extends Command implements CommandBusAwareInterface
+{
+    use CommandBusAwareTrait;
+}


### PR DESCRIPTION
Adds a console command factory.

Some deprecations were fixed. That means that minimum CakePHP requirement is bumped to 3.4 (for apps that doesn't feature console command bus integration, 3.6 is needed for that).